### PR TITLE
Fix benchmark csv

### DIFF
--- a/benchmark/map_bench_wordcount.csv
+++ b/benchmark/map_bench_wordcount.csv
@@ -2,22 +2,22 @@ Dart VM version: 0.5.0.1_r21823 (Mon Apr 22 14:02:11 2013), 535c1ae834b3bb23f004
 Dart VM version: 0.5.0.1_r21823 (Mon Apr 22 14:02:11 2013), 30cf32f6e403b60a8734b2d8780f39bcdee339e3, Thu Apr 25 17:40:55 UTC 2013, 1186.4
 Dart VM version: 0.5.1.0_r22072 (Fri Apr 26 12:54:33 2013), 32df58d26606334e00338c947c4f00fbdfc277ae, Mon Apr 29 21:16:52 UTC 2013, 883.4
 Dart VM version: 0.5.5.0_r22416 (Mon May  6 10:31:00 2013), c4c634e4d987c1461aa80e3d8627623ec04165f6, Tue May  7 21:58:28 UTC 2013, 663.5
-Dart VM version: 0.5.7.2_r22611 (Fri May 10 22:19:57 2013) on "linux_x64", 82ef833adcb9ff1af44ca3d02431cec36a605451, Mon May 13 23:00:06 UTC 2013, 2397.7
-Dart VM version: 0.5.9.0_r22879 (Sat May 18 21:32:26 2013) on "linux_x64", 18e8301013b444cc0a0ba89605dd784a6baf0546, Tue May 21 00:35:15 UTC 2013, 501.3
-Dart VM version: 0.5.11.1_r23200 (Mon May 27 00:02:29 2013) on "linux_x64", c08c2f50683e6ad8647ec2572bbb99a1d368a819, Wed Jun  5 06:18:28 UTC 2013, 581.8
-Dart VM version: 0.5.20.2_r24160 (Tue Jun 18 20:43:32 2013) on "linux_x64", 4004a85d1e6e9a9b16a39ea7d81b6cac7d80dc2f, Wed Jun 19 19:09:31 UTC 2013, 513.6
-Dart VM version: 0.6.3.3_r24898 (Thu Jul 11 07:47:12 2013) on "linux_x64", b1323f8a6bd330f89b48ca18e7821aab898a58c3, Tue Jul 16 00:01:25 UTC 2013, 522.8
-Dart VM version: 0.6.5.0_r25017 (Mon Jul 15 15:01:03 2013) on "linux_x64", 248ae0108cce466418185170214125b9ce0768bd, Wed Jul 17 22:35:09 UTC 2013, 528.6
-Dart VM version: 0.6.9.2_r25388 (Tue Jul 23 20:28:04 2013) on "linux_x64", 248ae0108cce466418185170214125b9ce0768bd, Fri Jul 26 20:37:00 UTC 2013, 506.0
-Dart VM version: 0.6.13.0_r25630 (Tue Jul 30 14:33:28 2013) on "linux_x64", 8c941a35b8168300626389780bacee56c6842552, Wed Jul 31 17:12:06 UTC 2013, 553.8
-Dart VM version: 0.6.15.3_r25822 (Tue Aug  6 13:39:55 2013) on "linux_x64", 196bed96bf2a209249aa945658e51567febe5006, Sun Aug 11 20:50:07 UTC 2013, 518.6
-Dart VM version: 0.7.3.1_r27487 (Fri Sep 13 13:27:39 2013) on "linux_x64", e1fbb8e11d30a9d7f7788d8846755aac296a0af4, Tue Sep 17 22:38:58 UTC 2013, 541.5
-Dart VM version: 0.7.5.3_r27776 (Mon Sep 23 14:31:35 2013) on "linux_x64", 800e9cc2bc700d9d87533772e8b537ae0fd42e46, Tue Sep 24 19:20:20 UTC 2013, 556.3
-Dart VM version: 0.7.6.4_r28108 (Tue Oct  1 14:32:31 2013) on "linux_x64", 5c80ab2f0f72d2607b41a2d08c80fe680449053b, Thu Oct  3 00:54:55 UTC 2013, 519.6
-Dart VM version: 0.8.5.1_r28990 (Tue Oct 22 04:50:58 2013) on "linux_x64", ffb7eee674f3be752956e8d99a9079ab4d3d8e3c, Tue Oct 22 19:41:31 UTC 2013, 559.7
-Dart VM version: 0.8.7.0_r29341 (Mon Oct 28 02:00:50 2013) on "linux_x64", 147768fc8239ad23d1074b5f4029d7dab0f2113d, Mon Oct 28 22:13:49 UTC 2013, 510.3
-Dart VM version: 0.8.10.8_r30039 (Thu Nov  7 03:03:33 2013) on "linux_x64", bd99a6c075b968fee23c541eee631e6396fbc262, Thu Nov  7 22:28:22 UTC 2013, 533.3
-Dart VM version: 1.1.0-dev.5.0 (Fri Dec 20 05:55:37 2013) on "linux_x64", 4cdf453c59369653d3e9432632ef4420e732fb36, Sat Jan  4 15:40:45 UTC 2014, 432.6
-Dart VM version: 1.2.0-dev.4.0 (Fri Feb  7 10:21:55 2014) on "linux_x64", 41c8cd12714847609f1647a4df5c20131cde759e, Tue Feb 11 22:37:52 UTC 2014, 463.3
-Dart VM version: 1.5.0-dev.2.0 (Mon May 26 07:29:28 2014) on "linux_x64", d3a3d1b4917de54dc1ddbe2f61169b35f21f85fb, Sun Jun  1 16:40:46 UTC 2014, 359.7
-Dart VM version: 1.5.0-dev.4.7 (Wed Jun 11 01:57:57 2014) on "linux_x64", dc6fe1c592a83e15d798a37f77013cafcb46c500, Thu Jun 12 09:00:32 UTC 2014, 345.6
+"Dart VM version: 0.5.7.2_r22611 (Fri May 10 22:19:57 2013) on ""linux_x64""", 82ef833adcb9ff1af44ca3d02431cec36a605451, Mon May 13 23:00:06 UTC 2013, 2397.7
+"Dart VM version: 0.5.9.0_r22879 (Sat May 18 21:32:26 2013) on ""linux_x64""", 18e8301013b444cc0a0ba89605dd784a6baf0546, Tue May 21 00:35:15 UTC 2013, 501.3
+"Dart VM version: 0.5.11.1_r23200 (Mon May 27 00:02:29 2013) on ""linux_x64""", c08c2f50683e6ad8647ec2572bbb99a1d368a819, Wed Jun  5 06:18:28 UTC 2013, 581.8
+"Dart VM version: 0.5.20.2_r24160 (Tue Jun 18 20:43:32 2013) on ""linux_x64""", 4004a85d1e6e9a9b16a39ea7d81b6cac7d80dc2f, Wed Jun 19 19:09:31 UTC 2013, 513.6
+"Dart VM version: 0.6.3.3_r24898 (Thu Jul 11 07:47:12 2013) on ""linux_x64""", b1323f8a6bd330f89b48ca18e7821aab898a58c3, Tue Jul 16 00:01:25 UTC 2013, 522.8
+"Dart VM version: 0.6.5.0_r25017 (Mon Jul 15 15:01:03 2013) on ""linux_x64""", 248ae0108cce466418185170214125b9ce0768bd, Wed Jul 17 22:35:09 UTC 2013, 528.6
+"Dart VM version: 0.6.9.2_r25388 (Tue Jul 23 20:28:04 2013) on ""linux_x64""", 248ae0108cce466418185170214125b9ce0768bd, Fri Jul 26 20:37:00 UTC 2013, 506.0
+"Dart VM version: 0.6.13.0_r25630 (Tue Jul 30 14:33:28 2013) on ""linux_x64""", 8c941a35b8168300626389780bacee56c6842552, Wed Jul 31 17:12:06 UTC 2013, 553.8
+"Dart VM version: 0.6.15.3_r25822 (Tue Aug  6 13:39:55 2013) on ""linux_x64""", 196bed96bf2a209249aa945658e51567febe5006, Sun Aug 11 20:50:07 UTC 2013, 518.6
+"Dart VM version: 0.7.3.1_r27487 (Fri Sep 13 13:27:39 2013) on ""linux_x64""", e1fbb8e11d30a9d7f7788d8846755aac296a0af4, Tue Sep 17 22:38:58 UTC 2013, 541.5
+"Dart VM version: 0.7.5.3_r27776 (Mon Sep 23 14:31:35 2013) on ""linux_x64""", 800e9cc2bc700d9d87533772e8b537ae0fd42e46, Tue Sep 24 19:20:20 UTC 2013, 556.3
+"Dart VM version: 0.7.6.4_r28108 (Tue Oct  1 14:32:31 2013) on ""linux_x64""", 5c80ab2f0f72d2607b41a2d08c80fe680449053b, Thu Oct  3 00:54:55 UTC 2013, 519.6
+"Dart VM version: 0.8.5.1_r28990 (Tue Oct 22 04:50:58 2013) on ""linux_x64""", ffb7eee674f3be752956e8d99a9079ab4d3d8e3c, Tue Oct 22 19:41:31 UTC 2013, 559.7
+"Dart VM version: 0.8.7.0_r29341 (Mon Oct 28 02:00:50 2013) on ""linux_x64""", 147768fc8239ad23d1074b5f4029d7dab0f2113d, Mon Oct 28 22:13:49 UTC 2013, 510.3
+"Dart VM version: 0.8.10.8_r30039 (Thu Nov  7 03:03:33 2013) on ""linux_x64""", bd99a6c075b968fee23c541eee631e6396fbc262, Thu Nov  7 22:28:22 UTC 2013, 533.3
+"Dart VM version: 1.1.0-dev.5.0 (Fri Dec 20 05:55:37 2013) on ""linux_x64""", 4cdf453c59369653d3e9432632ef4420e732fb36, Sat Jan  4 15:40:45 UTC 2014, 432.6
+"Dart VM version: 1.2.0-dev.4.0 (Fri Feb  7 10:21:55 2014) on ""linux_x64""", 41c8cd12714847609f1647a4df5c20131cde759e, Tue Feb 11 22:37:52 UTC 2014, 463.3
+"Dart VM version: 1.5.0-dev.2.0 (Mon May 26 07:29:28 2014) on ""linux_x64""", d3a3d1b4917de54dc1ddbe2f61169b35f21f85fb, Sun Jun  1 16:40:46 UTC 2014, 359.7
+"Dart VM version: 1.5.0-dev.4.7 (Wed Jun 11 01:57:57 2014) on ""linux_x64""", dc6fe1c592a83e15d798a37f77013cafcb46c500, Thu Jun 12 09:00:32 UTC 2014, 345.6

--- a/tool/run_all_benchmarks.sh
+++ b/tool/run_all_benchmarks.sh
@@ -7,5 +7,5 @@ GIT_HASH=`git rev-parse HEAD`
 DATE=`date -u`
 SCORE=`dart $ROOT_DIR/benchmark/map_bench_wordcount.dart`
 
-echo "$DART_VERSION, $GIT_HASH, $DATE, $SCORE" >> $ROOT_DIR/benchmark/map_bench_wordcount.csv
+echo "\"$( echo $DART_VERSION | sed "s/\"/\"\"/g" )\", $GIT_HASH, $DATE, $SCORE" >> $ROOT_DIR/benchmark/map_bench_wordcount.csv
 


### PR DESCRIPTION
Hey, noticed that github wasn't liking the wordcount benchmark csv so I fixed the unescaped double quotes.

Now it's more readable =) https://github.com/ajlai/persistent/blob/6c62f8a491dcaa6ead150721b46ce1032ff56f05/benchmark/map_bench_wordcount.csv
